### PR TITLE
Implement different freeze mode behavior and fixed parameter passing + names

### DIFF
--- a/urdf/common/dynaarm.ros2control.xacro
+++ b/urdf/common/dynaarm.ros2control.xacro
@@ -26,14 +26,12 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
     <state_interface name="motor_temperature_coil_B" />
     <state_interface name="motor_temperature_coil_C" />
     <state_interface name="motor_bus_voltage" />
-    <state_interface name="command_freeze_mode" />
     <command_interface name="position" />
     <command_interface name="velocity" />
     <command_interface name="effort" />
     <command_interface name="p_gain" />
     <command_interface name="i_gain" />
     <command_interface name="d_gain" />
-    <command_interface name="command_freeze_mode" />
   </xacro:macro>
 
   <xacro:macro name="dynaarm_ros2control_joint" params="name address">
@@ -43,8 +41,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
     </joint>
   </xacro:macro>
 
-  <xacro:macro name="dynaarm_ros2_control" params="tf_prefix">
-    <ros2_control name="DynaarmSystem" type="system">
+  <xacro:macro name="dynaarm_ros2_control" params="tf_prefix ethercat_bus start_in_freeze_mode">
+    <ros2_control name="${tf_prefix}DynaarmSystem" type="system">
       <hardware>
         <xacro:if value="${mode == 'sim'}">
           <plugin>gz_ros2_control/GazeboSimSystem</plugin>
@@ -56,6 +54,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
           <plugin>dynaarm_driver/DynaArmHardwareInterface</plugin>
           <param name="ethercat_bus">${ethercat_bus}</param>
           <param name="tf_prefix">${tf_prefix}</param>
+          <param name="start_in_freeze_mode">${start_in_freeze_mode}</param>
+
         </xacro:if>
       </hardware>
 
@@ -82,6 +82,9 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
       <xacro:if value="${dof >= 6}">
         <xacro:dynaarm_ros2control_joint name="${tf_prefix}WR_ROT" address="6" />
       </xacro:if>
+      <gpio name="${tf_prefix}DynaarmSystem">
+       <command_interface name="freeze_mode" />
+      </gpio>
 
     </ros2_control>
   </xacro:macro>

--- a/urdf/dynaarm.urdf.xacro
+++ b/urdf/dynaarm.urdf.xacro
@@ -31,7 +31,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <!-- DynaArm Macro-->
   <!-- -->
   <xacro:macro name="dynaarm"
-    params="tf_prefix parent_link dof mode ethercat_bus covers version *origin">
+    params="tf_prefix parent_link dof mode ethercat_bus start_in_freeze_mode:=false covers version *origin">
 
     <!-- Set ee_parent based on the specified DoF -->
     <xacro:property name="ee_parent" value="${base}" />
@@ -57,7 +57,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     </xacro:if>
 
     <!--ros2control-->
-    <xacro:dynaarm_ros2_control tf_prefix="${tf_prefix}" />
+    <xacro:dynaarm_ros2_control tf_prefix="${tf_prefix}" ethercat_bus="${ethercat_bus}" start_in_freeze_mode="${start_in_freeze_mode}"  />
   </xacro:macro>
 
   <!-- -->


### PR DESCRIPTION
Goes hand in hand with: https://github.com/Duatic/dynaarm_driver/pull/16

This PR might do a bit too much but it also fixes:

1. Passed parameters (ethercat bus was not properly exposed via the macro)
2. Use the tf_prefix for the hardware name -> Allows us to properly have multiple arms ;)