### PR TITLE
Allow changing the ethercat address for different arm versions

### DIFF
--- a/urdf/common/arowana4/drive_order.urdf.xacro
+++ b/urdf/common/arowana4/drive_order.urdf.xacro
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+Copyright 2024 Duatic AG
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<!--For the older arm the order of the drives is different on the ethercat bus. We create this mapping in order to account for this-->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+    <xacro:property name="ethercat_addresses" value="${list([1,3,2,6,5,4])}"/>
+</robot>

--- a/urdf/common/arowana4/dynaarm_parameters.urdf.xacro
+++ b/urdf/common/arowana4/dynaarm_parameters.urdf.xacro
@@ -25,6 +25,9 @@ OF
 THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property name="arm_version_name" value="arowana4"/>
+  <!-- Obtain the ethercat drive order (address order list)-->
+  <xacro:include filename="$(find dynaarm_description)/urdf/common/${arm_version_name}/drive_order.urdf.xacro"/>
 
   <xacro:property name="J_PI" value="3.14159265359" />
 

--- a/urdf/common/baracuda12/drive_order.urdf.xacro
+++ b/urdf/common/baracuda12/drive_order.urdf.xacro
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+Copyright 2024 Duatic AG
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<!--For the older arm the order of the drives is different on the ethercat bus. We create this mapping in order to account for this-->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+    <xacro:property name="ethercat_addresses" value="${list([1,2,3,4,5,6])}"/>
+</robot>

--- a/urdf/common/baracuda12/dynaarm_parameters.urdf.xacro
+++ b/urdf/common/baracuda12/dynaarm_parameters.urdf.xacro
@@ -25,6 +25,9 @@ OF
 THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:property name="arm_version_name" value="baracuda12"/>
+  <!-- Obtain the ethercat drive order (address order list)-->
+  <xacro:include filename="$(find dynaarm_description)/urdf/common/${arm_version_name}/drive_order.urdf.xacro"/>
 
   <xacro:property name="J_PI" value="3.14159265359" />
 

--- a/urdf/common/dynaarm.ros2control.xacro
+++ b/urdf/common/dynaarm.ros2control.xacro
@@ -41,7 +41,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
     </joint>
   </xacro:macro>
 
-  <xacro:macro name="dynaarm_ros2_control" params="tf_prefix ethercat_bus start_in_freeze_mode drive_parameter_folder drive_parameter_folder_default">
+  <xacro:macro name="dynaarm_ros2_control" params="tf_prefix ethercat_bus start_in_freeze_mode drive_parameter_folder drive_parameter_folder_default ethercat_addresses">
     <ros2_control name="${tf_prefix}DynaarmSystem" type="system">
       <hardware>
         <xacro:if value="${mode == 'sim'}">
@@ -62,27 +62,27 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
       </hardware>
 
       <xacro:if value="${dof >= 1}">
-        <xacro:dynaarm_ros2control_joint name="${tf_prefix}shoulder_rotation" address="1" />
+        <xacro:dynaarm_ros2control_joint name="${tf_prefix}shoulder_rotation" address="${ethercat_addresses[0]}" />
       </xacro:if>
 
       <xacro:if value="${dof >= 2}">
-        <xacro:dynaarm_ros2control_joint name="${tf_prefix}shoulder_flexion" address="2" />
+        <xacro:dynaarm_ros2control_joint name="${tf_prefix}shoulder_flexion" address="${ethercat_addresses[1]}" />
       </xacro:if>
 
       <xacro:if value="${dof >= 3}">
-        <xacro:dynaarm_ros2control_joint name="${tf_prefix}elbow_flexion" address="3" />
+        <xacro:dynaarm_ros2control_joint name="${tf_prefix}elbow_flexion" address="${ethercat_addresses[2]}" />
       </xacro:if>
 
       <xacro:if value="${dof >= 4}">
-        <xacro:dynaarm_ros2control_joint name="${tf_prefix}forearm_rotation" address="4" />
+        <xacro:dynaarm_ros2control_joint name="${tf_prefix}forearm_rotation" address="${ethercat_addresses[3]}" />
       </xacro:if>
 
       <xacro:if value="${dof >= 5}">
-        <xacro:dynaarm_ros2control_joint name="${tf_prefix}wrist_flexion" address="5" />
+        <xacro:dynaarm_ros2control_joint name="${tf_prefix}wrist_flexion" address="${ethercat_addresses[4]}" />
       </xacro:if>
 
       <xacro:if value="${dof >= 6}">
-        <xacro:dynaarm_ros2control_joint name="${tf_prefix}wrist_rotation" address="6" />
+        <xacro:dynaarm_ros2control_joint name="${tf_prefix}wrist_rotation" address="${ethercat_addresses[5]}" />
       </xacro:if>
       <gpio name="${tf_prefix}DynaarmSystem">
        <command_interface name="freeze_mode" />

--- a/urdf/dynaarm.urdf.xacro
+++ b/urdf/dynaarm.urdf.xacro
@@ -34,6 +34,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <xacro:macro name="dynaarm"
     params="tf_prefix parent_link dof mode ethercat_bus start_in_freeze_mode:=false drive_parameter_folder:='' covers version *origin">
 
+    <!--Allow the user to pass a custom folder for drive parameters-->
     <xacro:property name="default_drive_parameter_folder" value="$(find dynaarm_driver)/config/${version}" />
     <xacro:if value="${drive_parameter_folder == ''}">
       <xacro:property name="drive_parameter_folder_internal" value="${default_drive_parameter_folder}" />
@@ -45,6 +46,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <xacro:property name="ee_parent" value="${base}" />
 
     <xacro:include filename="$(find dynaarm_description)/urdf/common/dynaarm_common.urdf.xacro" />
+    <!-- Include the version specific information-->
     <xacro:include
       filename="$(find dynaarm_description)/urdf/common/${version}/dynaarm_parameters.urdf.xacro" />
     <xacro:include filename="$(find dynaarm_description)/urdf/common/dynaarm.ros2control.xacro" />
@@ -65,7 +67,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     </xacro:if>
 
     <!--ros2control-->
-    <xacro:dynaarm_ros2_control tf_prefix="${tf_prefix}" ethercat_bus="${ethercat_bus}" start_in_freeze_mode="${start_in_freeze_mode}"  drive_parameter_folder="${drive_parameter_folder_internal}" drive_parameter_folder_default="${default_drive_parameter_folder}" />
+    <xacro:dynaarm_ros2_control tf_prefix="${tf_prefix}" ethercat_bus="${ethercat_bus}" start_in_freeze_mode="${start_in_freeze_mode}"  drive_parameter_folder="${drive_parameter_folder_internal}" drive_parameter_folder_default="${default_drive_parameter_folder}" ethercat_addresses="${ethercat_addresses}"/>
   </xacro:macro>
 
   <!-- -->


### PR DESCRIPTION
This should fix the issue we ran into while testing with the old arms. 

In addition this PR adds a "arm_version_name" field in the arm specific xacro file. 