### PR TITLE
This adds a slight offset for all joints as start position 

### DIFF
--- a/urdf/common/dynaarm.ros2control.xacro
+++ b/urdf/common/dynaarm.ros2control.xacro
@@ -15,7 +15,10 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="dynaarm_joint_ros2control_joint_interfaces">
-    <state_interface name="position" />
+    <state_interface name="position">
+        <!-- Slightly offset the initial position for the gazebo sim-->
+        <param name="initial_value">0.05</param>
+    </state_interface>
     <state_interface name="velocity" />
     <state_interface name="effort" />
     <state_interface name="motor_position" />


### PR DESCRIPTION
It would be nicer to actually set it to the the middle between min and max value. But like this is works at least with moveit/movegroup now - otherwise the simulation may start out of bounds. 